### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-lint-check.yml
+++ b/.github/workflows/run-lint-check.yml
@@ -3,7 +3,10 @@ name: Check for print/console.log statements
 on:
   pull_request:
     branches: [ master ]
-    
+
+permissions:
+  contents: read
+
 jobs:
   call-lint-check:
     uses: Skill-Forge-Project/ci-templates/.github/workflows/lint-check.yml@master


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_frontend/security/code-scanning/1](https://github.com/Skill-Forge-Project/skill_forge_frontend/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block at the root level of the workflow. This block will explicitly define the permissions required for the workflow. Since the workflow is checking for print/console.log statements, it likely only needs read access to the repository contents. We will set `contents: read` as the minimal permission required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
