### PR TITLE
ISSUE #5-2: Add refresh token functionality - Frontend Enhancement

### DIFF
--- a/src/components/Admin/AddQuest.jsx
+++ b/src/components/Admin/AddQuest.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import "github-markdown-css/github-markdown.css";
 import CodeEditor from "../Layout/CodeEditor";
 import Modal from "../Layout/Modal";
+import { checkValidToken } from "../../services/authService";
 
 const AddQuest = () => {
   const userId = localStorage.getItem("userId");
@@ -57,24 +58,32 @@ const AddQuest = () => {
         body: JSON.stringify(payload),
       });
 
-      const data = await response.json();
+      const isTokenValid = await checkValidToken(response.status);
 
-      if (response.ok) {
-        setModalMessage("Quest created successfully!");
-        setModalOpen(true);
-        // Reset form data
-        setFormData({
-          quest_name: "",
-          quest_language: "",
-          quest_difficulty: "",
-          quest_condition: "",
-          function_template: "",
-          example_solution: "",
-          ...Array.from({ length: 10 }, (_, i) => ({
-            [`input_${i}`]: "",
-            [`output_${i}`]: ""
-          })).reduce((acc, curr) => ({ ...acc, ...curr }), {})
-        });
+      if (isTokenValid) {
+        const data = await response.json();
+
+        if (response.ok) {
+          setModalMessage("Quest created successfully!");
+          setModalOpen(true);
+          // Reset form data
+          setFormData({
+            quest_name: "",
+            quest_language: "",
+            quest_difficulty: "",
+            quest_condition: "",
+            function_template: "",
+            example_solution: "",
+            ...Array.from({ length: 10 }, (_, i) => ({
+              [`input_${i}`]: "",
+              [`output_${i}`]: ""
+            })).reduce((acc, curr) => ({ ...acc, ...curr }), {})
+          });
+        } else {
+          console.error("Error:", data.error);
+          setModalMessage("Quest creation failed: " + (data.error || "Unknown error"));
+          setModalOpen(true);
+        }
       } else {
         console.error("Error:", data.error);
         setModalMessage("Quest creation failed: " + (data.error || "Unknown error"));

--- a/src/components/Admin/EditQuestPage.jsx
+++ b/src/components/Admin/EditQuestPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { editQuestById } from "../../services/questsServices";
 import CodeEditor from "../Layout/CodeEditor";
 import Modal from "../Layout/Modal";
+import { checkValidToken } from "../../services/authService";
 
 
 const EditQuestPage = ({ questId, onBack }) => {
@@ -96,12 +97,19 @@ const EditQuestPage = ({ questId, onBack }) => {
         },
         body: JSON.stringify(payload),
       });
+
+      const isTokenValid = await checkValidToken(response.status);
+
+      if (isTokenValid) {
+        const data = await response.json();
   
-      const data = await response.json();
-  
-      if (response.ok) {
-        setModalMessage("Quest updated successfully!");
-        setModalOpen(true);
+        if (response.ok) {
+          setModalMessage("Quest updated successfully!");
+          setModalOpen(true);
+        } else {
+          setModalMessage("Failed to update quest.");
+          setModalOpen(true);
+        }
       } else {
         setModalMessage("Failed to update quest.");
         setModalOpen(true);

--- a/src/components/Admin/NewBoss.jsx
+++ b/src/components/Admin/NewBoss.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Modal from "../Layout/Modal";
+import { checkValidToken } from '../../services/authService';
 
 const NewBoss = () => {
   const UNDERWORLD_API_URL = import.meta.env.VITE_UNDERWORLD_SERVICE_URL;
@@ -44,11 +45,18 @@ const NewBoss = () => {
         }),
       });
 
-      const data = await response.json();
+      const isTokenValid = await checkValidToken(response.status);
 
-      if (response.ok) {
-        setModalMessage("Boss created successfully!");
-        setModalOpen(true);
+      if (isTokenValid) {
+        const data = await response.json();
+
+        if (response.ok) {
+          setModalMessage("Boss created successfully!");
+          setModalOpen(true);
+        } else {
+          setModalMessage("Boss creation failed: " + (data.message || "Unknown error"));
+          setModalOpen(true);
+        }
       } else {
         setModalMessage("Boss creation failed: " + (data.message || "Unknown error"));
         setModalOpen(true);

--- a/src/components/Auth/LoginForm.jsx
+++ b/src/components/Auth/LoginForm.jsx
@@ -24,6 +24,7 @@ export default function LoginForm() {
     try {
       const response = await login(form);
       localStorage.setItem("token", response.access_token);
+      localStorage.setItem("refresh_token", response.refresh_token)
       localStorage.setItem("userId", response.user_id);
       // alert("Login successful"); // Debug only!
       navigate("/dashboard");

--- a/src/components/Layout/Navbar.jsx
+++ b/src/components/Layout/Navbar.jsx
@@ -16,7 +16,7 @@ export default function Navbar() {
 
 
   useEffect(() => {
-    if (userId && token) {
+    if (userId) {
       getAvatarUrl(userId, token, USER_API).then((url) => {
         setAvatarUrl(url);
       });

--- a/src/components/UserProfile/ProfileMain.jsx
+++ b/src/components/UserProfile/ProfileMain.jsx
@@ -8,6 +8,7 @@ import InstagramIcon from "../../assets/img/social_media_icons/instagram.png";
 import GithubIcon from "../../assets/img/social_media_icons/github.svg";
 import DiscordIcon from "../../assets/img/social_media_icons/discord.svg";
 import LinkedInIcon from "../../assets/img/social_media_icons/linkedin.png";
+import { checkValidToken } from "../../services/authService";
 
 const ProfileMain = ({ user, setModalOpen, setModalMessage }) => {
   const [formData, setFormData] = useState({
@@ -59,10 +60,17 @@ const ProfileMain = ({ user, setModalOpen, setModalMessage }) => {
         }
       );
 
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.message || "Upload failed");
-      setModalMessage("Avatar updated successfully!");
-      setModalOpen(true);
+      const isTokenValid = await checkValidToken(res.status);
+
+      if (isTokenValid) {
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.message || "Upload failed");
+        setModalMessage("Avatar updated successfully!");
+        setModalOpen(true);
+      } else {
+        setModalMessage("Avatar upload failed.");
+        setModalOpen(true);
+      }
     } catch (err) {
       setModalMessage("Avatar upload failed.");
       setModalOpen(true);

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -6,6 +6,7 @@ import Achievements from "../components/UserProfile/Achievements";
 import UserStats from "../components/UserProfile/UserStats";
 import Modal from "../components/Layout/Modal";
 import { getUserById, getAvatarUrl } from "../services/usersService";
+import { checkValidToken } from "../services/authService";
 
 const ProfilePage = () => {
   const [user, setUser] = useState(null);
@@ -37,20 +38,26 @@ const ProfilePage = () => {
           },
         });
 
-        if (!response.ok) {
-          throw new Error("Failed to fetch avatar");
-        }
+        const isTokenValid = await checkValidToken(response.status);
 
-        // Convert blob to object URL
-        const imageBlob = await response.blob();
-        const imageObjectUrl = URL.createObjectURL(imageBlob);
-        setAvatarUrl(imageObjectUrl);
+        if (isTokenValid) {
+          if (!response.ok) {
+            throw new Error("Failed to fetch avatar");
+          }
+
+          // Convert blob to object URL
+          const imageBlob = await response.blob();
+          const imageObjectUrl = URL.createObjectURL(imageBlob);
+          setAvatarUrl(imageObjectUrl);
+        } else {
+          console.error("Error fetching avatar URL:", err.message);
+        }
       } catch (err) {
         console.error("Error fetching avatar URL:", err.message);
       }
     };
 
-    if (userId && token) {
+    if (userId) {
       fetchUserData();
       fetchAvatarUrl();
     }

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -52,6 +52,8 @@ export const checkValidToken = async (responseStatus) => {
 
       return true;
     }
+
+    return false;
   }
 
   return true;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -34,6 +34,8 @@ export const signup = async (data) => {
 };
 
 
+// Checks if access token is valid
+// If access token has expired, a request to the refresh_access_token endpoint is sent and the access token is reset
 export const checkValidToken = async (responseStatus) => {
   if (responseStatus === 401) {
     const refreshToken = localStorage.getItem("refresh_token");

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -32,3 +32,27 @@ export const signup = async (data) => {
 
   return responseData;
 };
+
+
+export const checkValidToken = async (responseStatus) => {
+  if (responseStatus === 401) {
+    const refreshToken = localStorage.getItem("refresh_token");
+
+    const res = await fetch(`${AUTH_API}/refresh_access_token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${refreshToken}`,
+      }
+    })
+
+    if (res.ok) {
+      const newAccessToken = await res.json();
+      localStorage.setItem("token", newAccessToken.access_token);
+
+      return true;
+    }
+  }
+
+  return true;
+}

--- a/src/services/questsServices.js
+++ b/src/services/questsServices.js
@@ -1,3 +1,5 @@
+import { checkValidToken } from "./authService";
+
 const QUESTS_API = import.meta.env.VITE_QUESTS_SERVICE_URL;
 
 // Get all quests from the Quests Service
@@ -10,9 +12,14 @@ export const getAllQuests = async () => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch quests");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch quests");
+  }
 };
 
 // Get all quests by language from the Quests Service
@@ -25,9 +32,14 @@ export const getQuestsByLanguage = async (language) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch quests");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch quests");
+  }
 };
 
 // Get a single quest by ID from the Quests Service
@@ -40,9 +52,14 @@ export const getQuestById = async (questId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch quest");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch quest");
+  }
 };
 
 
@@ -56,9 +73,14 @@ export const editQuestById = async (questId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch quest");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch quest");
+  }
 };
 
 // Get all solutions for a user
@@ -71,9 +93,14 @@ export const getSolvedQuestsByUserId = async (userId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch solved quests");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch solved quests");
+  }
 };
 
 // Get all correct solutions for a user
@@ -86,7 +113,12 @@ export const getCorrectSolutionsByUserId = async (userId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch correct solutions");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch correct solutions");
+  }
 };

--- a/src/services/underworldService.js
+++ b/src/services/underworldService.js
@@ -1,3 +1,5 @@
+import { checkValidToken } from "./authService";
+
 const UNDERWORLD_API_URL = import.meta.env.VITE_UNDERWORLD_SERVICE_URL;
 
 // Get all boses from the Underworld Service
@@ -10,9 +12,14 @@ export const getAllBosses = async () => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch bosses");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch bosses");
+  }
 };
 
 // Get a single boss by ID from the Underworld Service
@@ -25,26 +32,36 @@ export const getBossById = async (bossId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch boss");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch boss");
+  }
 };
 
 // Create a new boss in the Underworld Service (as Admin)
 export const createBoss = async (formData) => {
-    const token = localStorage.getItem("token");
+  const token = localStorage.getItem("token");
 
-    const res = await fetch(`${UNDERWORLD_API_URL}/bosses`, {
-        method: "POST",
-        headers: {
-            "Authorization": `Bearer ${token}`,
-        },
-        body: formData,
-    });
+  const res = await fetch(`${UNDERWORLD_API_URL}/bosses`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${token}`,
+    },
+    body: formData,
+  });
 
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
     const data = await res.json();
-    if (!res.ok) throw new Error(data.message || "Failed to create boss");
     return data;
+  } else {
+    throw new Error(data.message || "Failed to create boss");
+  }
 };
 
 // Generate new Underworld Challenge
@@ -60,7 +77,12 @@ export const generateChallenge = async (bossId, challengeData) => {
     body: JSON.stringify(challengeData),
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to generate challenge");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to generate challenge");
+  }
 };

--- a/src/services/useAvatarUrl.js
+++ b/src/services/useAvatarUrl.js
@@ -1,5 +1,7 @@
 // Fetch the user avatar from the server
 
+import { checkValidToken } from "./authService";
+
 
 export async function getAvatarUrl(userId, token, userApiBase) {
     try {
@@ -8,11 +10,15 @@ export async function getAvatarUrl(userId, token, userApiBase) {
           Authorization: `Bearer ${token}`,
         },
       });
-  
-      if (!response.ok) throw new Error("Failed to fetch avatar");
-  
-      const blob = await response.blob();
-      return URL.createObjectURL(blob);
+
+      const isTokenValid = await checkValidToken(response.status);
+
+      if (isTokenValid && response.ok) {
+        const blob = await response.blob();
+        return URL.createObjectURL(blob);
+      } else {
+        throw new Error("Failed to fetch avatar");
+      }
     } catch (err) {
       console.error("Error fetching avatar:", err);
       return null;

--- a/src/services/usersService.js
+++ b/src/services/usersService.js
@@ -1,3 +1,5 @@
+import { checkValidToken } from "./authService";
+
 const USER_API = import.meta.env.VITE_USERS_SERVICE_URL;
 
 // Get all users from the Users Service
@@ -9,9 +11,14 @@ export const getAllUsers = async () => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch users");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch users");
+  }
 };
 
 // Get a single user by ID from the Users Service
@@ -23,9 +30,14 @@ export const getUserById = async (userId) => {
     },
   });
 
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to fetch user");
-  return data;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to fetch user");
+  }
 };
 
 // Get user avatar URL
@@ -40,8 +52,13 @@ export const getAvatarUrl = async (userId) => {
     },
   });
 
-  if (!res.ok) throw new Error("Failed to fetch avatar URL");
-  return res.url;
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    return res.url;
+  } else {
+    throw new Error("Failed to fetch avatar URL");
+  }
 };
 
 // Update user information based on user ID
@@ -55,7 +72,13 @@ export const updateUser = async (userId, updatedData) => {
     },
     body: JSON.stringify(updatedData),
   });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.message || "Failed to update user");
-  return data;
+
+  const isTokenValid = await checkValidToken(res.status);
+
+  if (isTokenValid && res.ok) {
+    const data = await res.json();
+    return data;
+  } else {
+    throw new Error(data.message || "Failed to update user");
+  }
 };


### PR DESCRIPTION
### 🧾 Summary
Implemented automatic access token refresh on the frontend by intercepting 401 Unauthorized responses. If a request fails due to an expired access token, a new token is requested using the refresh token, and the original request is retried seamlessly.

---

## 🧩 Issue Description
Previously, when a JWT access token expired, the frontend would not handle it gracefully. Users were left with a broken or unresponsive interface and were forced to log in again manually. There was no mechanism in place to renew tokens or maintain session continuity.

---

## 💡 Proposed Solution
Created a centralized function that checks if an API response returns a 401 status. If it does, the function sends a request to the backend token refresh endpoint using the stored refresh token, receives a new access token, updates local storage, and retries the original request. This logic is reused across all services that make authenticated requests.

---

## 🧪 Testing Instructions
<!-- Describe how you tested your changes. Include specific test cases, environments, or commands used. -->

- [x] Tested locally with an expired access token to verify automatic token renewal.
- [x] Verified that requests are retried successfully after receiving a new token.
- [x] Confirmed the flow works across all authenticated routes in the app.

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, especially in hard-to-understand areas.
- [x] The feature has sufficient test coverage.
- [x] No new warnings or errors introduced.

---

## 🔗 Related Issue(s) (if applicable)

- Related to #5 

---

## 📝 Additional Notes (Optional)
- To Do:
   - [ ] When the refresh token expires, the user need to be redirected to Login page.
   - [ ] If there are issues with the refreshing page after changes in localStorage, we should consider using useState() in the frontend for the tokens.

